### PR TITLE
Fix for loading byte-compiled file

### DIFF
--- a/python-docstring.el
+++ b/python-docstring.el
@@ -32,7 +32,9 @@
 ;;; Code:
 
 (defvar python-docstring-script
-  (concat (file-name-as-directory (file-name-directory #$))
+  (concat (if load-file-name
+              (file-name-directory load-file-name)
+            default-directory)
           "docstring_wrap.py")
   "The location of the docstring_wrap.py script.")
 


### PR DESCRIPTION
'#$' is nil if file is byte-compiled then error occurs.
Because file-name-directory does not accept nil argument.

How to reproduce error
1. Byte-compile `python-docstring.el`
2. Load `python-docstring.elc` which is generated by step 1
3. The error `(wrong-type-argument stringp nil)` is occurred
