### PR TITLE
Add autoload cookies.

### DIFF
--- a/python-docstring.el
+++ b/python-docstring.el
@@ -36,6 +36,7 @@
           "docstring_wrap.py")
   "The location of the docstring_wrap.py script.")
 
+;;;###autoload
 (defun python-docstring-fill ()
   "Wrap Python docstrings as epytext or ReStructured Text."
   (interactive)
@@ -142,6 +143,7 @@
     ;; inline markup - 1
     (,python-docstring-epytext-markup-style-italic 1 (quote italic) t)))
 
+;;;###autoload
 (define-minor-mode python-docstring-mode
   "Toggle python-docstring-mode.
 With no argument, this command toggles the mode.
@@ -158,6 +160,7 @@ Null prefix argument turns off the mode."
      (font-lock-add-keywords nil python-docstring-keywords)
    (font-lock-remove-keywords nil python-docstring-keywords)))
 
+;;;###autoload
 (defun python-docstring-install ()
   "Add python-docstring-mode as a hook to python.mode."
   (add-hook 'python-mode-hook (lambda () (python-docstring-mode t))))


### PR DESCRIPTION
Fixes #8.

Installing this with [cask](http://cask.readthedocs.org/) doesn't work by default, since there are no autoloads.
