### PR TITLE
Use global setting as a default in python-docstring-sentence-end-double-space

### DIFF
--- a/python-docstring.el
+++ b/python-docstring.el
@@ -31,7 +31,7 @@
 
 ;;; Code:
 
-(defcustom python-docstring-sentence-end-double-space t
+(defcustom python-docstring-sentence-end-double-space sentence-end-double-space
   "If non-nil, use double spaces when formatting text.
 
 Operates simililarly to `sentence-end-double-space'.  When nil, a


### PR DESCRIPTION
I am on the fence about this diff. 

On one hand, PEP8 explicitly suggests one uses double spaces after the sentence end in a comment, so `t` might indeed be a good default. 

On the other, when a user has explicitly set up a global `sentence-end-double-space` to `nil`, it's probably a good idea to respect this setting in a docstring _by default_.  `python-mode` seems to be respecting this default out of the box, so seeing a different behavior inside a docstring was an unpleasant surprise.

Best,
Ivan
