### PR TITLE
Add Microsoft Windows support

### DIFF
--- a/python-docstring.el
+++ b/python-docstring.el
@@ -110,9 +110,10 @@ of the string."
   (shell-command-on-region
    string-start string-end
    (format
-    (concat "python3 %s --offset %s --indent %s --width %s"
+    (concat "%s %s --offset %s --indent %s --width %s"
 	    (unless python-docstring-sentence-end-double-space
 	      " --single-space"))
+    (if (eq system-type 'windows-nt) "py -3" "python3")
     (shell-quote-argument python-docstring-script)
     orig-offset
     indent-count


### PR DESCRIPTION
By default this package does not work on Windows.  It doesn't fill the docstring, instead it destroys the docstring, because there are no `python3` executable on Windows.

My simple fix is: use `py -3` instead of `python3` on Windows, which is the correct way as introduced [in the official documentation](https://docs.python.org/3/using/windows.html#from-the-command-line).

Moreover, if the user have no Python installed, `python-docstring-fill` destroys the docstring, too.  This is very rare as the user is already editing some Python files.