### PR TITLE
Add Generator docstring fields

### DIFF
--- a/python-docstring.el
+++ b/python-docstring.el
@@ -170,7 +170,7 @@ same offset within the string."
   "^\\s-*\\([@:]\\)\\(param\\|parameter\\|arg\\|argument\\|type\\|keyword\\|kwarg\\|kwparam\\|raise\\|raises\\|except\\|exception\\|ivar\\|ivariable\\|cvar\\|cvariable\\|var\\|variable\\|type\\|group\\|todo\\|newfield\\)\\s-+\\(~*[a-zA-Z_][a-zA-Z0-9_,. ]*?\\)\\(:\\)")
 
 (defvar python-docstring-field-no-arg-re
-  "^\\s-*\\([@:]\\)\\(raise\\|raises\\|return\\|returns\\|rtype\\|returntype\\|type\\|sort\\|see\\|seealso\\|note\\|attention\\|bug\\|warning\\|warn\\|version\\|todo\\|deprecated\\|since\\|status\\|change\\|changed\\|permission\\|requires\\|require\\|requirement\\|precondition\\|precond\\|postcondition\\|postcod\\|invariant\\|author\\|organization\\|org\\|copyright\\|(c)\\|license\\|contact\\|summary\\|params\\|param\\)\\(:\\)")
+  "^\\s-*\\([@:]\\)\\(raise\\|raises\\|return\\|returns\\|rtype\\|returntype\\|yield\\|yields\\|ytype\\|yieldtype\\|send\\|sends\\|stype\\|sendtype\\|type\\|sort\\|see\\|seealso\\|note\\|attention\\|bug\\|warning\\|warn\\|version\\|todo\\|deprecated\\|since\\|status\\|change\\|changed\\|permission\\|requires\\|require\\|requirement\\|precondition\\|precond\\|postcondition\\|postcod\\|invariant\\|author\\|organization\\|org\\|copyright\\|(c)\\|license\\|contact\\|summary\\|params\\|param\\)\\(:\\)")
 
 (defvar python-docstring-epytext-markup-link "[UL]{\\([^}]*?\\)\\(<.*?>\\|\\)?}")
 (defvar python-docstring-epytext-markup-style-code "C{\\(.*?\\)}")


### PR DESCRIPTION
Adds support for `yields` and `sends`-like fields to python docstrings.

This is a nice feature to have when adding doctrings for [Generator/Iterator](https://docs.python.org/3/library/typing.html#typing.Generator) type functions where you typically document `yields`+`sends` instead of `returns`

